### PR TITLE
Fixes It.IsRegex issue with non-constant arguments

### DIFF
--- a/src/Moq.ILogger/VerifyLogExtensions.cs
+++ b/src/Moq.ILogger/VerifyLogExtensions.cs
@@ -579,7 +579,7 @@ namespace Moq
                             case "IsRegex":
                                 {
                                     // build (v, t) => Regex.IsMatch(v.ToString(), pattern, RegexOptions.IgnoreCase)
-                                    var pattern = ((ConstantExpression)methodCallExpression.Arguments[0]).Value;
+                                    var pattern = Expression.Lambda(methodCallExpression.Arguments[0]).Compile().DynamicInvoke();
                                     var patternConstantExpression = Expression.Constant(pattern);
                                     var regexOptionsConstantExpression = Expression.Constant(RegexOptions.IgnoreCase);
                                     var vParamToStringExpression = CreatevParamToStringExpression();

--- a/tests/Moq.ILogger.Tests/VerifyLogExtensionsTests.cs
+++ b/tests/Moq.ILogger.Tests/VerifyLogExtensionsTests.cs
@@ -556,6 +556,18 @@ namespace Moq.Tests
         }
 
         [Fact]
+        public void Verify_it_is_regex_with_method_call_it_verifies()
+        {
+            var loggerMock = new Mock<ILogger>();
+            loggerMock.Object.LogInformation("Test message");
+
+            Action act = () => loggerMock.VerifyLog(c => c.LogInformation(It.IsRegex(GetRegex())));
+
+            act.Should().NotThrow();
+        }
+        string GetRegex() => "^(.*)$";
+
+        [Fact]
         public void Verify_it_is_regex_when_message_does_not_match_the_regex_it_throws()
         {
             var loggerMock = new Mock<ILogger>();


### PR DESCRIPTION
Assume the provided argument to It.IsRegex could be any expression
so just compile and invoke the expression

Fixes issue #3