### PR TITLE
Times.Never is not properly evaluated

### DIFF
--- a/src/Moq.ILogger/VerifyLogExtensions.cs
+++ b/src/Moq.ILogger/VerifyLogExtensions.cs
@@ -437,8 +437,10 @@ namespace Moq
                     {
                         loggerMock.Verify(verifyExpression, times.Value, failMessage);
                     }
-
-                    loggerMock.Verify(verifyExpression, failMessage);
+                    else
+                    {
+                        loggerMock.Verify(verifyExpression, failMessage);
+                    }
                 }
                 catch (MockException ex)
                 {

--- a/tests/Moq.ILogger.Tests/Moq.ILogger.Tests.csproj
+++ b/tests/Moq.ILogger.Tests/Moq.ILogger.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>Latest</LangVersion>
   </PropertyGroup>

--- a/tests/Moq.ILogger.Tests/VerifyLogExtensionsTests.cs
+++ b/tests/Moq.ILogger.Tests/VerifyLogExtensionsTests.cs
@@ -811,6 +811,28 @@ namespace Moq.Tests
                 .WithMessage("*Expected invocation on the mock at least 2 times, but was 1 time*")
                 .WithMessage("*We expect to log `Test message` at least twice.*");
         }
+
+        [Fact]
+        public void Verify_uses_Times_Never()
+        {
+            var loggerMock = new Mock<ILogger<object>>();
+
+            Action act = () => loggerMock.VerifyLog(logger => logger.LogDebug("Test message"), Times.Never());
+
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Verify_includes_the_fail_message_with_Times_Never()
+        {
+            var loggerMock = new Mock<ILogger<object>>();
+            loggerMock.Object.LogDebug("Test message");
+
+            Action act = () => loggerMock.VerifyLog(logger => logger.LogDebug("Test message"), Times.Never);
+
+            act.Should().ThrowExactly<VerifyLogException>()
+                .WithMessage("*Expected invocation on the mock should never have been performed, but was 1 time*");
+        }
     }
 
     internal static class OtherExtensions


### PR DESCRIPTION
The behind loggerMock.Verify was called twice
for the times overload.

So if times is Times.Never and the sut implementation
is valid, the first verify call is not throwing, as expected.

But the second loggerMock.Verify was also called with default values
and the test reported a false negative, as the sut implementation
was correct, but test improperly failed expecting a call on sut's method.

Fixes issue #4