### PR TITLE
Fix issue with the verification of the message args array

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ public void Verify_semantic_logging()
 
     loggerMock.VerifyLog(logger => logger.LogInformation("Processed {@Position} in {Elapsed:000} ms.", new { Latitude = 25, Longitude = 134 }, 34));
     loggerMock.VerifyLog(logger => logger.LogInformation("Processed {@Position} in {Elapsed:000} ms.", It.IsAny<It.IsAnyType>(), It.IsAny<int>()));
+    loggerMock.VerifyLog(logger => logger.LogInformation("Processed {@Position} in {Elapsed:000} ms.", It.Is<object[]>(arg => arg != null)));
 
     // wildcard usages
     loggerMock.VerifyLog(logger => logger.LogInformation("Processed { Latitude = *, Longitude = * } in * ms."));

--- a/src/Moq.ILogger/VerifyLogExpression.cs
+++ b/src/Moq.ILogger/VerifyLogExpression.cs
@@ -12,7 +12,7 @@ namespace Moq
         public Expression ExceptionExpression { get; private set; }
         public Expression EventIdExpression { get; private set; }
         public Expression MessageArgsExpression { get; private set; }
-        public bool HasExpectedMessageArgs => ((NewArrayExpression) MessageArgsExpression).Expressions.Count > 0;
+        public bool HasExpectedMessageArgs => MessageArgsExpression is MethodCallExpression || (MessageArgsExpression as NewArrayExpression)?.Expressions.Count > 0;
 
         public static VerifyLogExpression From(Expression expression) =>
             new VerifyLogExpression

--- a/tests/Moq.ILogger.Tests/Samples/SomeClassTests.cs
+++ b/tests/Moq.ILogger.Tests/Samples/SomeClassTests.cs
@@ -97,6 +97,7 @@ namespace Moq.Tests.Samples
 
             loggerMock.VerifyLog(logger => logger.LogInformation("Processed {@Position} in {Elapsed:000} ms.", new { Latitude = 25, Longitude = 134 }, 34));
             loggerMock.VerifyLog(logger => logger.LogInformation("Processed {@Position} in {Elapsed:000} ms.", It.IsAny<It.IsAnyType>(), It.IsAny<int>()));
+            loggerMock.VerifyLog(logger => logger.LogInformation("Processed {@Position} in {Elapsed:000} ms.", It.Is<object[]>(arg => arg != null)));
 
             loggerMock.VerifyLog(logger => logger.LogInformation("Processed { Latitude = *, Longitude = * } in * ms."));
             loggerMock.VerifyLog(logger => logger.LogInformation("Processed * in * ms."));

--- a/tests/Moq.ILogger.Tests/VerifyLogExtensionsTests.cs
+++ b/tests/Moq.ILogger.Tests/VerifyLogExtensionsTests.cs
@@ -1,7 +1,7 @@
+using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using System;
 using Xunit;
-using FluentAssertions;
 
 // ReSharper disable once CheckNamespace
 namespace Moq.Tests
@@ -392,6 +392,35 @@ namespace Moq.Tests
 
             act.Should().ThrowExactly<VerifyLogException>()
                 .WithMessage("*.LogInformation*");
+        }
+
+        [Fact]
+        public void Verify_when_args_array_is_matched_it_verifies()
+        {
+            var loggerMock = new Mock<ILogger>();
+            var position = new { Latitude = 25, Longitude = 134 };
+            var elapsedMs = 34;
+            loggerMock.Object.LogInformation("Processed {@Position} in {Elapsed:000} ms.", position, elapsedMs);
+
+            Action act = () => loggerMock.VerifyLog(logger => logger.LogInformation("Processed {@Position} in {Elapsed:000} ms.",
+                It.IsAny<object[]>()));
+
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Verify_when_args_array_is_not_matched_it_throws()
+        {
+            var loggerMock = new Mock<ILogger>();
+            var position = new { Latitude = 25, Longitude = 134 };
+            var elapsedMs = 34;
+            loggerMock.Object.LogInformation("Processed {@Position} in {Elapsed:000} ms.", position, elapsedMs);
+
+            Action act = () => loggerMock.VerifyLog(logger => logger.LogInformation("Processed {@Position} in {Elapsed:000} ms.",
+                It.Is<object[]>(o => o == null)));
+
+            act.Should().ThrowExactly<VerifyLogException>()
+                .WithMessage("*Expected invocation on the mock at least once*(o => o == null)*");
         }
 
         [Fact]


### PR DESCRIPTION
Moq can define a valid verification expression that addresses
the array behind the _params_ keyword.

Handling this correctly with Moq.ILogger too so now
something like
```
    loggerMock.VerifyLog(logger => logger.LogInformation("Processed {@Position} in {Elapsed:000} ms.", It.Is<object[]>(arg => arg != null)));
```
could be used

Closes #10 